### PR TITLE
Test bugs

### DIFF
--- a/src/adjtransblockbanded.jl
+++ b/src/adjtransblockbanded.jl
@@ -1,3 +1,9 @@
-
+Base.transpose(bs::BlockBandedSizes) = BlockBandedSizes(
+    BlockSizes(reverse(bs.block_sizes.cumul_sizes)),
+    blockbandwidth(bs, 2), blockbandwidth(bs, 1))
+Base.transpose(bs::BandedBlockBandedSizes) = BandedBlockBandedSizes(
+    BlockSizes(reverse(bs.block_sizes.cumul_sizes)),
+    bs.u, bs.l, bs.μ, bs.λ)
+blocksizes(A::AdjOrTrans) = transpose(blocksizes(parent(A)))
 blockbandwidths(A::AdjOrTrans) = reverse(blockbandwidths(parent(A)))
 subblockbandwidths(A::AdjOrTrans) = reverse(subblockbandwidths(parent(A)))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -134,7 +134,7 @@ function blocksizes(V::SubBlockBandedMatrix{<:Any,BlockRange1,BlockRange1})
 
     @assert KR[1] == JR[1] == 1
     BlockBandedSizes(BlockSizes((Bs.cumul_sizes[1][KR[1]:KR[end]+1] .- Bs.cumul_sizes[1][KR[1]] .+ 1,
-                                 Bs.cumul_sizes[2][JR[1]:JR[end]+1] .- Bs.cumul_sizes[1][JR[1]] .+ 1)),
+                                 Bs.cumul_sizes[2][JR[1]:JR[end]+1] .- Bs.cumul_sizes[2][JR[1]] .+ 1)),
                         blockbandwidth(A,1) - shift, blockbandwidth(A,2) + shift)
 end
 

--- a/test/test_adjtransblockbanded.jl
+++ b/test/test_adjtransblockbanded.jl
@@ -1,4 +1,6 @@
 using BlockBandedMatrices
+using BlockBandedMatrices: BlockBandedSizes, BandedBlockBandedSizes
+using BlockArrays: BlockSizes
 
 @testset "Adj/Trans" begin
     A = BandedBlockBandedMatrix(randn(ComplexF64,10,14), (1:4,2:5), (1,2), (2,1))
@@ -13,4 +15,21 @@ using BlockBandedMatrices
 
     @test BandedBlockBandedMatrix(A') == A'
     @test BandedBlockBandedMatrix(transpose(A)) == transpose(A)
+end
+
+@testset "blocksize transpose" begin
+    a = BlockBandedSizes(BlockSizes(rand(1:10, 3), rand(1:10, 4)), rand(1:10), rand(1:10))
+    @test transpose(a).block_sizes.cumul_sizes[1] == a.block_sizes.cumul_sizes[2]
+    @test transpose(a).block_sizes.cumul_sizes[2] == a.block_sizes.cumul_sizes[1]
+    @test blockbandwidth(transpose(a), 2) == blockbandwidth(a, 1)
+    @test blockbandwidth(transpose(a), 1) == blockbandwidth(a, 2)
+
+    a = BandedBlockBandedSizes(BlockSizes(rand(1:10, 3), rand(1:10, 4)),
+                               rand(1:10), rand(1:10), rand(1:10), rand(1:10))
+    @test transpose(a).block_sizes.cumul_sizes[1] == a.block_sizes.cumul_sizes[2]
+    @test transpose(a).block_sizes.cumul_sizes[2] == a.block_sizes.cumul_sizes[1]
+    @test transpose(a).l == a.u
+    @test transpose(a).u == a.l
+    @test transpose(a).λ == a.μ
+    @test transpose(a).μ == a.λ
 end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -11,11 +11,11 @@ using BlockArrays, BandedMatrices, BlockBandedMatrices, LazyArrays, LinearAlgebr
     C = BandedBlockBandedMatrix{Float64}(undef, (1:2,1:2), (1,1), (1,1))
     C.data .= NaN
     lmul!(0.0, C)
-    norm(C) == 0.0
+    @test norm(C) == 0.0
 
     C.data .= NaN
     rmul!(C, 0.0)
-    norm(C) == 0.0
+    @test norm(C) == 0.0
 end
 
 @testset "BlockBandedMatrix linear algebra" begin

--- a/test/test_triblockbanded.jl
+++ b/test/test_triblockbanded.jl
@@ -6,7 +6,7 @@ import BlockBandedMatrices: MemoryLayout, TriangularLayout, BandedBlockBandedCol
 
 @testset "triangular BandedBlockBandedMatrix mul" begin
     A = BandedBlockBandedMatrix{Float64}(undef, (1:10,1:10), (1,1), (1,1))
-        A.data .= randn.()
+    A.data .= randn.()
 
     U = UpperTriangular(A)
     @test MemoryLayout(U) == TriangularLayout{'U','N'}(BandedBlockBandedColumnMajor())
@@ -158,7 +158,7 @@ end
 
     @test size(V) == (5,3)
     b = randn(size(V,2))
-    @test_broken all(V*b .=== Matrix(V)*b .=== BLAS.gemv!('N', 1.0, V, b, 0.0, Vector{Float64}(undef, size(V,1))))
+    @test all(V*b .=== Matrix(V)*b .=== BLAS.gemv!('N', 1.0, V, b, 0.0, Vector{Float64}(undef, size(V,1))))
 
     V = view(A, Block.(1:3), Block(3)[2:3])
     @test_throws ArgumentError pointer(V)
@@ -174,7 +174,7 @@ end
 
     @test size(V) == (5,2)
     b = randn(size(V,2))
-    @test_broken all(V*b .=== Matrix(V)*b .=== BLAS.gemv!('N', 1.0, V, b, 0.0, Vector{Float64}(undef, size(V,1))))
+    @test all(V*b .=== Matrix(V)*b .=== BLAS.gemv!('N', 1.0, V, b, 0.0, Vector{Float64}(undef, size(V,1))))
 
     V = view(A, Block.(1:3), Block(3)[2:3])
     @test_throws ArgumentError pointer(V)


### PR DESCRIPTION
- adds blocksizes for SubBlockBandedMatrix, so that [this test](https://github.com/JuliaMatrices/BlockBandedMatrices.jl/blob/a158e88caa11df8ecdb75072dce2d8853a371f55/test/test_bandedblockbanded.jl#L284)  passes
- adds some missing `@test`

@dlfivefifty, I'm kinda stabbing in the dark here, so please check this is correct.

Also, is the [this line](https://github.com/JuliaMatrices/BlockBandedMatrices.jl/blob/a158e88caa11df8ecdb75072dce2d8853a371f55/src/linalg.jl#L115) correct? or should it read:

```Julia
Bs.cumul_sizes[2][JR[1]:JR[end]+1] .- Bs.cumul_sizes[****** 2 ******][JR[1]] .+ 1)),
```

Because, if it is correct then I definitely do not understand what I'm doing :blush:, and this PR should be closed.