### PR TITLE
Don't import maybetail

### DIFF
--- a/src/BlockBandedMatrices.jl
+++ b/src/BlockBandedMatrices.jl
@@ -56,9 +56,6 @@ const BlockIndexRange1{R<:AbstractUnitRange{Int}} = BlockIndexRange{1,Tuple{R}}
 blockcolrange(A...) = blockcolsupport(A...)
 blockrowrange(A...) = blockrowsupport(A...)
 
-_maybetail(::Tuple{}) = ()
-_maybetail(t::Tuple) = tail(t)
-
 include("AbstractBlockBandedMatrix.jl")
 include("broadcast.jl")
 include("BlockSkylineMatrix.jl")

--- a/src/BlockBandedMatrices.jl
+++ b/src/BlockBandedMatrices.jl
@@ -6,7 +6,7 @@ import Base: getindex, setindex!, checkbounds, @propagate_inbounds, convert,
                         +, *, -, /, \, strides, zeros, size,
                         unsafe_convert, fill!, length, first, last,
                         eltype, getindex, to_indices, to_index,
-                        reindex, _maybetail, tail, @_propagate_inbounds_meta,
+                        reindex, tail, @_propagate_inbounds_meta,
                         ==, axes, copy, copyto!, similar, OneTo
 
 import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, DefaultArrayStyle, Broadcasted, broadcasted,
@@ -55,6 +55,9 @@ const BlockIndexRange1{R<:AbstractUnitRange{Int}} = BlockIndexRange{1,Tuple{R}}
 
 blockcolrange(A...) = blockcolsupport(A...)
 blockrowrange(A...) = blockrowsupport(A...)
+
+_maybetail(::Tuple{}) = ()
+_maybetail(t::Tuple) = tail(t)
 
 include("AbstractBlockBandedMatrix.jl")
 include("broadcast.jl")


### PR DESCRIPTION
`Base._maybetail` has been renamed to `Base.safe_tail` on julia nightly. Since this is an internal function, it's best if we define it ourselves int his package.

Edit: It appears that this function isn't used at all in this package, so I've removed it for now.