### PR TITLE
Return a BandedMatrix from a view of a BandedBlockBandedMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ BlockBandedMatricesSparseArraysExt = "SparseArrays"
 [compat]
 Aqua = "0.8"
 ArrayLayouts = "1"
-BandedMatrices = "1"
+BandedMatrices = "1.9.4"
 BlockArrays = "1"
 Documenter = "1"
 FillArrays = "1"

--- a/src/BandedBlockBandedMatrix.jl
+++ b/src/BandedBlockBandedMatrix.jl
@@ -346,7 +346,8 @@ end
     if -A.u ≤ K-J ≤ A.l
         inbands_viewblock(A, KJ)
     else
-        _BandedMatrix(view(A.data, Block(1,1)), blocklengths(A,1)[Block(K)], (-40320,-40320))
+        dat = view(A.data, Block(1,1))
+        _BandedMatrix(dat, length(axes(A,1)[Block(K)]), size(dat,1)-1,0)
     end
 end
 

--- a/src/BlockBandedMatrices.jl
+++ b/src/BlockBandedMatrices.jl
@@ -24,7 +24,7 @@ import BlockArrays: AbstractBlockLayout, AbstractBlockedUnitRange, Block, BlockI
                     _blockkron, _blocklengths2blocklasts, block,
                     blockcheckbounds, blockcolstart, blockcolstop, blockcolsupport, blockindex, blockisequal,
                     blockrowstart, blockrowstop, blockrowsupport, blocks, blocksize, checksquareblocks,
-                    hasmatchingblocks, sizes_from_blocks
+                    hasmatchingblocks, sizes_from_blocks, viewblock
 
 import FillArrays: Fill, Ones, Zeros
 


### PR DESCRIPTION
@MikaelSlevinsky  This gets rid of the allocations (for lazy axes at least). 

Still need to figure out why it's slow.

```julia
julia> for n in 20:20:200
                  ax = BlockArrays.BlockedOneTo(ArrayLayouts.RangeCumsum(Base.OneTo(n)))
                  D = BandedBlockBandedMatrix{Float64}(I, (ax,ax), (0, 0), (0, 0))
                  x = BlockVector(randn(sum(1:n)), (ax,))
                  y = zero(x)
                  @time my_special_mul_through_data!(y, D, x);
                  @time mul!(y, D, x);
              end
  0.000002 seconds
  0.000066 seconds (1 allocation: 32 bytes)
  0.000004 seconds
  0.000035 seconds (1 allocation: 32 bytes)
  0.000007 seconds
  0.000045 seconds (1 allocation: 32 bytes)
  0.000011 seconds
  0.000056 seconds (1 allocation: 32 bytes)
  0.000016 seconds
  0.000140 seconds (1 allocation: 32 bytes)
  0.000023 seconds
  0.000172 seconds (1 allocation: 32 bytes)
  0.000057 seconds
  0.000179 seconds (1 allocation: 32 bytes)
  0.000041 seconds
  0.000316 seconds (1 allocation: 32 bytes)
  0.000067 seconds
  0.000180 seconds (1 allocation: 32 bytes)
  0.000062 seconds
  0.000212 seconds (1 allocation: 32 bytes)
```