### PR TITLE
Add a cconvert for each unsafe_convert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           - 'min'
           - 'lts'
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1']
+        julia-version: ['1', 'nightly']
         os: [ubuntu-latest]
         package:
           - {repo: ApproxFunBase.jl, group: JuliaApproximation}

--- a/src/BlockSkylineMatrix.jl
+++ b/src/BlockSkylineMatrix.jl
@@ -456,6 +456,9 @@ _parent_blocks(V::BlockBandedBlock)::Tuple{Int,Int} =
 MemoryLayout(::Type{<:BlockBandedBlock}) = ColumnMajor()
 Base.elsize(::Type{<:BlockSkylineMatrix{T,R}}) where {T,R} = Base.elsize(R)
 
+function Base.cconvert(::Type{Ptr{T}}, V::BlockBandedBlock{T}) where T
+    V
+end
 function Base.unsafe_convert(::Type{Ptr{T}}, V::BlockBandedBlock{T}) where T
     A = parent(V)
     K,J = _parent_blocks(V)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,6 +105,7 @@ sub_materialize(::BlockLayout{<:AbstractBandedLayout}, V, _) = BlockBandedMatrix
 strides(V::SubBlockSkylineMatrix{<:Any,LL,UU,<:Union{BlockRange1,Block1},Block1}) where {LL,UU} =
     (1,parent(V).block_sizes.block_strides[Int(parentindices(V)[2].block)])
 
+
 function Base.cconvert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:Union{BlockRange1,Block1},Block1}) where {T,LL,UU}
     V
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -105,7 +105,9 @@ sub_materialize(::BlockLayout{<:AbstractBandedLayout}, V, _) = BlockBandedMatrix
 strides(V::SubBlockSkylineMatrix{<:Any,LL,UU,<:Union{BlockRange1,Block1},Block1}) where {LL,UU} =
     (1,parent(V).block_sizes.block_strides[Int(parentindices(V)[2].block)])
 
-
+function Base.cconvert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:Union{BlockRange1,Block1},Block1}) where {T,LL,UU}
+    V
+end
 function unsafe_convert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:Union{BlockRange1,Block1},Block1}) where {T,LL,UU}
     A = parent(V)
     JR = parentindices(V)[2]
@@ -117,6 +119,9 @@ end
 strides(V::SubBlockSkylineMatrix{<:Any,LL,UU,<:BlockRange1,<:BlockIndexRange1}) where {LL,UU} =
     (1,parent(V).block_sizes.block_strides[Int(Block(parentindices(V)[2]))])
 
+function Base.cconvert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:BlockRange1,<:BlockIndexRange1}) where {T,LL,UU}
+    V
+end
 function unsafe_convert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:BlockRange1,<:BlockIndexRange1}) where {T,LL,UU}
     A = parent(V)
     JR = parentindices(V)[2]
@@ -127,6 +132,9 @@ function unsafe_convert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,<:Block
     p + sizeof(T)*(JR.block.indices[1][1]-1)*stride(V,2)
 end
 
+function Base.cconvert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,BlockIndexRange1,BlockIndexRange1}) where {T,LL,UU}
+    V
+end
 function unsafe_convert(::Type{Ptr{T}}, V::SubBlockSkylineMatrix{T,LL,UU,BlockIndexRange1,BlockIndexRange1}) where {T,LL,UU}
     A = parent(V)
     JR = parentindices(V)[2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,47 @@ using BlockBandedMatrices
 using ParallelTestRunner
 
 const init_code = quote
-   using Test
-   using BlockBandedMatrices
+    using Test
+    using BlockBandedMatrices
+
+    function strided_ptr(f, a::AbstractArray{T}) where {T}
+        a_cconv = Base.cconvert(Ptr{T}, a)
+        GC.@preserve a_cconv begin
+            f(Base.unsafe_convert(Ptr{T}, a_cconv))
+        end
+    end
+
+    """
+        check_strided_get(a::AbstractArray{T,N})
+
+    Test that array `a` implements the strided array interface for reading.
+    Checks stride consistency and that `unsafe_load` matches `getindex`.
+    """
+    function check_strided_get(a::AbstractArray{T,N})::Nothing where {T, N}
+        if !isbitstype(eltype(a))
+            error("a doesn't have isbits elements")
+        end
+        # Putting strided_ptr before the loop means that strided_ptr shouldn't error for empty arrays
+        strided_ptr(a) do a_ptr
+            for d in 1:N
+                if stride(a, d) != strides(a)[d]
+                    error("stride(a, d) doesn't equal strides(a)[d] for dimension $(d)")
+                end
+            end
+            for i in CartesianIndices(a)
+                el_ptr = a_ptr
+                for d in 1:N
+                    stride_in_bytes = stride(a, d) * Base.elsize(typeof(a))
+                    first_idx = first(axes(a, d))
+                    el_ptr += (i[d] - first_idx) * stride_in_bytes
+                end
+                if unsafe_load(el_ptr) !== a[i]
+                    error("getindex and unsafe_load mismatch at index $(i)")
+                end
+            end
+        end
+        nothing
+    end
 end
 
 # Start with autodiscovered tests

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -10,6 +10,7 @@ using Test
 
 import BandedMatrices: BandError, bandeddata
 import BlockBandedMatrices: _BandedBlockBandedMatrix
+import ..check_strided_get
 
 @testset "lmul!/rmul!" begin
     C = BandedBlockBandedMatrix{Float64}(undef, 1:2,1:2, (1,1), (1,1))
@@ -45,6 +46,7 @@ end
     @test stride(V,2) == 7
     @test unsafe_load(pointer(V)) == 46
     @test unsafe_load(pointer(V) + stride(V,2)*sizeof(Float64)) == 53
+    check_strided_get(V)
 
     x = randn(size(A,2))
     @test A*x == (similar(x) .= MulAdd(A,x)) ≈ Matrix(A)*x
@@ -87,6 +89,7 @@ end
 
     V = view(A, Block(2), Block(2))
     @test unsafe_load(Base.unsafe_convert(Ptr{Float64}, bandeddata(V))) == 13.0
+    check_strided_get(bandeddata(V))
 
     C = BandedMatrix{Float64}(undef, size(V), 2 .*bandwidths(V))
     C .= MulAdd(V,V)

--- a/test/test_triblockbanded.jl
+++ b/test/test_triblockbanded.jl
@@ -12,6 +12,7 @@ import BlockBandedMatrices: MemoryLayout, TriangularLayout,
                             blockrowstop, blockcolstop, ColumnMajor
 
 import BlockArrays: blockisequal
+import ..check_strided_get
 
 @testset "triangular" begin
     @testset "triangular BandedBlockBandedMatrix mul" begin
@@ -156,6 +157,7 @@ import BlockArrays: blockisequal
         @test unsafe_load(pointer(V)) == A[2,4]
         @test unsafe_load(pointer(V)+sizeof(Float64)*stride(V,2)) == A[2,5]
         @test MemoryLayout(typeof(V)) == ColumnMajor()
+        check_strided_get(V)
 
         @test size(V) == (5,3)
         b = randn(size(V,2))
@@ -174,6 +176,7 @@ import BlockArrays: blockisequal
         @test unsafe_load(pointer(V)) == A[2,5]
         @test unsafe_load(pointer(V)+sizeof(Float64)*stride(V,2)) == A[2,6]
         @test MemoryLayout(typeof(V)) == ColumnMajor()
+        check_strided_get(V)
 
         @test size(V) == (5,2)
         b = randn(size(V,2))
@@ -194,6 +197,8 @@ import BlockArrays: blockisequal
         V_22 = view(A, Block(N)[1:N],  Block(N)[1:N])
         @test unsafe_load(pointer(V_22)) == V_22[1,1] == V[1,1]
         @test strides(V_22) == strides(V) == (1,9)
+        check_strided_get(V_22)
+        check_strided_get(V)
         b = randn(N)
         @test copyto!(similar(b) , MulAdd(V,b)) == copyto!(similar(b) , MulAdd(V_22,b)) ==
             Matrix(V)*b ==


### PR DESCRIPTION
This fixes the tests broken by changes in https://github.com/JuliaLang/julia/pull/60533

A follow-up would organize things so that `Base.unsafe_convert(Ptr{T}, A.data)` isn't called.

But this PR should restore behavior to what it was before https://github.com/JuliaLang/julia/pull/60533